### PR TITLE
Fix DriveSettings.cs

### DIFF
--- a/Code/Program/NetworkShareMapper/DriveSettings.cs
+++ b/Code/Program/NetworkShareMapper/DriveSettings.cs
@@ -113,7 +113,7 @@ namespace NetworkShareMapper
             if (mapDrive == true)
             {
                 myLogWriter.LogWrite("Will now connect " + sDriveLetter + " to " + sNetworkPath);
-                int connectionResult = WNetAddConnection2(ref oNetworkResource, Username, Password, 0);
+                int connectionResult = WNetAddConnection2(ref oNetworkResource, Password, Username, 0);
 
                 if (connectionResult == 0)
                     myLogWriter.LogWrite("Drive mapping completed successfully.");


### PR DESCRIPTION
Fix major Bug, Microsoft expects password first, then username:

DWORD WNetAddConnection2A(
  [in] LPNETRESOURCEA lpNetResource,
  [in] LPCSTR         lpPassword,
  [in] LPCSTR         lpUserName,
  [in] DWORD          dwFlags
);